### PR TITLE
Task 4: Jenkins Setup with Helm and JCasC

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,4 @@ To deploy Jenkins with auto-configured job:
 ```bash
 helm upgrade --install jenkins jenkins/jenkins -n jenkins -f jenkins-values.yaml
 
+


### PR DESCRIPTION
This pull request completes Task 4 by setting up a Jenkins instance on Minikube using Helm.

Included:
- Helm chart deployment of Jenkins in a dedicated namespace
- PVC verification on Minikube
- Sample freestyle job that echoes "Hello world"
- Job managed via Jenkins Configuration as Code (JCasC)
- Supporting files: README, helm values, kubectl output, and screenshots

Jenkins was verified through the browser and tested end-to-end.
